### PR TITLE
Don't use "as" as a SQL alias

### DIFF
--- a/source/_posts/2015-04-13-doctrine-orm-optimization-hydration.md
+++ b/source/_posts/2015-04-13-doctrine-orm-optimization-hydration.md
@@ -260,19 +260,19 @@ LEFT JOIN
 SELECT
     u.id         AS userId,
     u.username   AS userUsername,
-    s.id         AS socialAccountId,
-    s.username   AS socialAccountUsername,
-    s.type       AS socialAccountType,
-    as.id        AS sessionId,
-    as.expiresOn AS sessionExpiresOn,
+    sa.id        AS socialAccountId,
+    sa.username  AS socialAccountUsername,
+    sa.type      AS socialAccountType,
+    s.id         AS sessionId,
+    s.expiresOn  AS sessionExpiresOn,
 FROM
     user u
 LEFT JOIN
-    socialAccount s
-        ON s.userId = u.id
+    socialAccount sa
+        ON sa.userId = u.id
 LEFT JOIN
-    session as
-        ON as.userId = u.id
+    session s
+        ON s.userId = u.id
 ~~~
 
 <p>
@@ -467,15 +467,15 @@ LEFT JOIN
 
 ~~~sql
 SELECT
-    u.id         AS userId,
-    u.username   AS userUsername,
-    as.id        AS sessionId,
-    as.expiresOn AS sessionExpiresOn,
+    u.id        AS userId,
+    u.username  AS userUsername,
+    s.id        AS sessionId,
+    s.expiresOn AS sessionExpiresOn,
 FROM
     user u
 LEFT JOIN
-    session as
-        ON as.userId = u.id
+    session s
+        ON s.userId = u.id
 ~~~
 
 <p>


### PR DESCRIPTION
While reading the blog post, the two sections modified made me do a double take. I know it's perfectly valid SQL, but reading "as.id AS sessionId" threw me off.  I renamed the aliases to not use "as".