### PR TITLE
Move some links to HTTPS

### DIFF
--- a/source/_posts/2012-08-06-zend-framework-2-controllers-and-dependency-injection-with-zend-di.md
+++ b/source/_posts/2012-08-06-zend-framework-2-controllers-and-dependency-injection-with-zend-di.md
@@ -65,10 +65,10 @@ summary: A quick overview of how to use Zend\Di from Zend Framework 2 to retriev
 <p>
     <span class="label label-info">For the lazy:</span> If you just prefer to look at the code and run it
     without having to reproduce my example, you can just look at the already modified skeleton at
-    <a href="http://github.com/Ocramius/ZendSkeletonApplication/tree/demo/zf2-controllers-from-zend-di/module">
+    <a href="https://github.com/Ocramius/ZendSkeletonApplication/tree/demo/zf2-controllers-from-zend-di/module">
         Ocramius/ZendSkeletonApplication - branch demo/zf2-controllers-from-zend-di
     </a> and see what I did in the
-    <a href="http://github.com/Ocramius/ZendSkeletonApplication/compare/master...demo;zf2-controllers-from-zend-di" target="_blank">diff</a>.
+    <a href="https://github.com/Ocramius/ZendSkeletonApplication/compare/master...demo;zf2-controllers-from-zend-di" target="_blank">diff</a>.
 </p>
 
 <p>
@@ -324,19 +324,19 @@ return array(
 <p>
    <span class="label label-info">Note:</span>  Please also note that in this example, all dependency injection
      are based on type hints of concret  implementations. I cleaned up my code and invite you to check
-    <a href="http://github.com/Ocramius/ZendSkeletonApplication/tree/demo/zf2-controllers-from-zend-di-cleanup/module" target="_blank">
+    <a href="https://github.com/Ocramius/ZendSkeletonApplication/tree/demo/zf2-controllers-from-zend-di-cleanup/module" target="_blank">
         Ocramius/ZendSkeletonApplication - demo/zf2-controllers-from-zend-di-cleanup
     </a> and see what I did in the
-    <a href="http://github.com/Ocramius/ZendSkeletonApplication/compare/demo;zf2-controllers-from-zend-di...demo;zf2-controllers-from-zend-di-cleanup" target="_blank">diff</a>.
+    <a href="https://github.com/Ocramius/ZendSkeletonApplication/compare/demo;zf2-controllers-from-zend-di...demo;zf2-controllers-from-zend-di-cleanup" target="_blank">diff</a>.
     In this case I simply exchanged the type hints with abstract types (which allow more flexibility) and taught
     <code>Zend\Di</code> how to handle injections for them.
 </p>
 
 <p>
     To check how I improved performance using <code>ocramius/ocra-di-compiler</code>, please refer to branch
-    <a href="http://github.com/Ocramius/ZendSkeletonApplication/tree/demo/zf2-controllers-from-zend-di-with-compiled-di/module" target="_blank">
+    <a href="https://github.com/Ocramius/ZendSkeletonApplication/tree/demo/zf2-controllers-from-zend-di-with-compiled-di/module" target="_blank">
         Ocramius/ZendSkeletonApplication - demo/zf2-controllers-from-zend-di-with-compiled-di
-    </a> and to the related <a href="http://github.com/Ocramius/ZendSkeletonApplication/compare/demo;zf2-controllers-from-zend-di-cleanup...demo;zf2-controllers-from-zend-di-with-compiled-di" target="_blank">diff</a>.
+    </a> and to the related <a href="https://github.com/Ocramius/ZendSkeletonApplication/compare/demo;zf2-controllers-from-zend-di-cleanup...demo;zf2-controllers-from-zend-di-with-compiled-di" target="_blank">diff</a>.
 </p>
 
 <hr/>

--- a/source/_posts/2012-08-16-automated-code-coverage-check-for-github-pull-requests-with-travis.md
+++ b/source/_posts/2012-08-16-automated-code-coverage-check-for-github-pull-requests-with-travis.md
@@ -45,14 +45,14 @@ tweet: 236012181685170177
     least a given percentage of the
     <a href="http://pdepend.org/documentation/software-metrics/index.html" target="_blank">]
         <abbr title="Executable Lines Of Code">ELOC</abbr></a>.
-    The script should exit with an <a href="http://en.wikipedia.org/wiki/Exit_status" target="_blank">exit code</a>
+    The script should exit with an <a href="https://en.wikipedia.org/wiki/Exit_status" target="_blank">exit code</a>
     different from <strong>1</strong> if the check wasn't successful, thus being recognized by our test runner as a
     failure.
 </p>
 <p>
-    I will use <a href="http://travis-ci.org/" target="_blank">Travis-CI</a> for my examples, but what I am going to
+    I will use <a href="https://travis-ci.org/" target="_blank">Travis-CI</a> for my examples, but what I am going to
     show can be easily integrated also in other
-    <a href="http://en.wikipedia.org/wiki/Continuous_integration" target="_blank">Continuous Integration</a>
+    <a href="https://en.wikipedia.org/wiki/Continuous_integration" target="_blank">Continuous Integration</a>
     environments.
 </p>
 
@@ -117,8 +117,8 @@ tweet: 236012181685170177
 <h2>The PHP script</h2>
 <p>
     And here's the PHP script that will handle all this. It is just using
-    <a href="http://www.php.net/manual/en/simplexml.examples-basic.php" target="_blank">SimpleXMLElement</a> and
-    an <a href="http://en.wikipedia.org/wiki/XPath" target="_blank">XPath</a> expression to find elements relevant
+    <a href="https://secure.php.net/manual/en/simplexml.examples-basic.php" target="_blank">SimpleXMLElement</a> and
+    an <a href="https://en.wikipedia.org/wiki/XPath" target="_blank">XPath</a> expression to find elements relevant
     to us and extract them from the XML.
 </p>
 

--- a/source/_posts/2012-09-12-asset-manager-for-zend-framework-2.md
+++ b/source/_posts/2012-09-12-asset-manager-for-zend-framework-2.md
@@ -22,7 +22,7 @@ summary: A tutorial to start using assets from your modules within your ZF2 appl
 <h2>ZF2 Module structure</h2>
 <p>
     When <a href="https://twitter.com/weierophinney" target="_blank">Matthew Weier
-    O'Phinney</a> blogged about <a href="http://mwop.net/blog/why-conventions-matter.html"
+    O'Phinney</a> blogged about <a href="https://mwop.net/blog/why-conventions-matter.html"
     target="_blank">Why Conventions Matter</a> in ZF2 Modules, we were still defining the
     basic concepts of modules, and didn't really have a decent solution about how to
     serve assets. The idea is to ship assets with modules themselves, thus avoiding to
@@ -31,7 +31,7 @@ summary: A tutorial to start using assets from your modules within your ZF2 appl
 </p>
 <p>
     AssetManager solves this problem and is a
-    <a href="http://ocramius.github.io/blog/automated-code-coverage-check-for-github-pull-requests-with-travis/"
+    <a href="https://ocramius.github.io/blog/automated-code-coverage-check-for-github-pull-requests-with-travis/"
     target="_blank">high quality and well tested module</a>.
 </p>
 
@@ -40,7 +40,7 @@ summary: A tutorial to start using assets from your modules within your ZF2 appl
 <p>
     We will use a standard <a href="https://github.com/zendframework/ZendSkeletonApplication"
     target="_blank">ZF2 skeleton application</a> and
-    <a href="http://getcomposer.org/" target="_blank">Composer</a>:
+    <a href="https://getcomposer.org/" target="_blank">Composer</a>:
 </p>
 
 ~~~sh

--- a/source/_posts/2012-11-19-zf2-and-symfony-service-proxies-with-doctrine-proxies.md
+++ b/source/_posts/2012-11-19-zf2-and-symfony-service-proxies-with-doctrine-proxies.md
@@ -14,7 +14,7 @@ tweet: 270851711395045377
 <h2>Dependency Injection Containers and Performance</h2>
 
 <p>
-    <a href="http://en.wikipedia.org/wiki/Dependency_injection" target="_blank">Dependency Injection Containers</a>
+    <a href="https://en.wikipedia.org/wiki/Dependency_injection" target="_blank">Dependency Injection Containers</a>
     are a vital tool for developers of complex and modular applications.
     <br/>
     Using a Dependency Injection Container in your application brings you great benefits, allowing you to compose
@@ -103,7 +103,7 @@ class HelloWorld
 
 <p>
     To solve the performance issues, some may be tempted to start using a
-    <a href="http://martinfowler.com/articles/injection.html#UsingAServiceLocator" target="_blank">Service Locator</a>
+    <a href="https://martinfowler.com/articles/injection.html#UsingAServiceLocator" target="_blank">Service Locator</a>
     within their services:
 </p>
 ~~~php
@@ -202,8 +202,8 @@ class HelloWorld
 <p>
     <a href="https://github.com/Ocramius/common/blob/DCOM-96/lib/Doctrine/Common/Proxy/Proxy.php"
     target="_blank">Doctrine Proxies</a> are a PHP implementation of the
-    <a href="http://en.wikipedia.org/wiki/Proxy_pattern" target="_blank">proxy pattern</a> used to achieve
-    <a href="http://www.martinfowler.com/eaaCatalog/lazyLoad.html" target="_blank">lazy loading</a> of objects from
+    <a href="https://en.wikipedia.org/wiki/Proxy_pattern" target="_blank">proxy pattern</a> used to achieve
+    <a href="https://www.martinfowler.com/eaaCatalog/lazyLoad.html" target="_blank">lazy loading</a> of objects from
     a persistent storage.
     <br/>
     Doctrine implements this pattern by having <strong>Virtual Proxies</strong> that behave like
@@ -247,7 +247,7 @@ class UserProxy extends User
 <p>
     The implementation has been enhanced with <a href="https://github.com/doctrine/common/pull/168" target="_blank">
     a patch I'm working on</a>, now allowing many different uses of the proxy pattern. This is mainly possible
-    because of <a href="http://php.net/manual/en/functions.anonymous.php" target="_blank">lambda functions</a>
+    because of <a href="https://secure.php.net/manual/en/functions.anonymous.php" target="_blank">lambda functions</a>
     used as initialization logic holders:
 </p>
 ~~~php
@@ -274,7 +274,7 @@ class UserProxy extends User
 }
 ~~~
 <p>
-    Using a <a href="http://php.net/manual/en/class.closure.php" target="_blank">Closure</a> as an initializer
+    Using a <a href="https://secure.php.net/manual/en/class.closure.php" target="_blank">Closure</a> as an initializer
     now enables us to swap the initialization logic used for our proxy object. I won't get into details, but this
     is a requirement for our next step.
 </p>
@@ -361,7 +361,7 @@ class HelloWorld
 <ol>
     <li>
         You can now pass an instance of <code>D_Proxy</code> to <code>HelloWorld</code>. Since <code>D_Proxy</code>
-        extends <code>D</code>, it respects the <a href="http://en.wikipedia.org/wiki/Liskov_substitution_principle"
+        extends <code>D</code>, it respects the <a href="https://en.wikipedia.org/wiki/Liskov_substitution_principle"
         target="_blank">Liskov substitution principle</a>.
     </li>
     <li>
@@ -486,7 +486,7 @@ class HelloWorld
     on writing clean and robust classes that are easy to test.
 </p>
 <p>
-    They surely add some hidden magic to our code, and I've been already told by <a href="http://mwop.net/" target="_blank">
+    They surely add some hidden magic to our code, and I've been already told by <a href="https://mwop.net/" target="_blank">
     Matthew Weier 'o Phinney</a> that some newcomers may be confused by the additional calls they will in stack
     traces when looking at exceptions. Since proxies are an optional feature, I'm not really concerned about it.
 </p>

--- a/source/_posts/2013-02-14-doctrine-2-orm-zf2-tutorial.md
+++ b/source/_posts/2013-02-14-doctrine-2-orm-zf2-tutorial.md
@@ -15,8 +15,8 @@ description: Slides I wrote to guide newcomers while integrating Doctrine 2 ORM 
     A couple of weeks ago, I spoke about integrating
     <a href="https://github.com/doctrine/doctrine2" target="_blank">Doctrine 2 ORM</a> in
     <a href="https://github.com/zendframework/zf2" target="_blank">Zend Framework 2</a> applications in a
-    <a href="http://www.zend.com/en/webinars/recorded/show/336_doctrine%202%20orm%20and%20zend%20framework%202%20an%20introduction%20to%20doctrinemodule" target="_blank">webinar</a>
-    that I prepared for <a href="http://twitter.com/webinarsatzend" target="_blank">@webinarsatzend</a>.
+    <a href="https://www.zend.com/en/webinars/recorded/show/336_doctrine%202%20orm%20and%20zend%20framework%202%20an%20introduction%20to%20doctrinemodule" target="_blank">webinar</a>
+    that I prepared for <a href="https://twitter.com/webinarsatzend" target="_blank">@webinarsatzend</a>.
 </p>
 <p>
     You can find my slides at

--- a/source/_posts/2013-06-30-intercepting-public-property-access-in-php.md
+++ b/source/_posts/2013-06-30-intercepting-public-property-access-in-php.md
@@ -57,7 +57,7 @@ class Foo
 
 <p>
     In order to do so, we can use a simple wrapper for our <code>Foo</code> object. Because we want to
-    respect the <a title="Liskov Substitution Principle" href="http://en.wikipedia.org/wiki/Liskov_substitution_principle" target="_blank">LSP</a>,
+    respect the <a title="Liskov Substitution Principle" href="https://en.wikipedia.org/wiki/Liskov_substitution_principle" target="_blank">LSP</a>,
     we have this wrapper extending <code>Foo</code>:
 </p>
 
@@ -86,7 +86,7 @@ echo $foo->publicProperty;
 ~~~
 
 <p>
-    Weirdly, this <a href="http://3v4l.org/gRtoj" target="_blank">will produce</a>
+    Weirdly, this <a href="https://3v4l.org/gRtoj" target="_blank">will produce</a>
     something like following:
 </p>
 
@@ -144,7 +144,7 @@ echo $foo->publicProperty = 'test';
 ~~~
 
 <p>
-    This <a href="http://3v4l.org/mmMZU" target="_blank">will produce</a> following output:
+    This <a href="https://3v4l.org/mmMZU" target="_blank">will produce</a> following output:
 </p>
 
 ~~~sh

--- a/source/_posts/2013-07-10-accessing-private-php-class-members-without-reflection.md
+++ b/source/_posts/2013-07-10-accessing-private-php-class-members-without-reflection.md
@@ -19,13 +19,13 @@ tweet: 354936007868686337
 </p>
 <p>
     The problem is simple: instantiating
-    <a href="http://php.net/manual/en/class.reflectionclass.php" target="_blank">ReflectionClass</a> or
-    <a href="http://php.net/manual/en/class.reflectionproperty.php" target="_blank">ReflectionProperty</a> is
+    <a href="https://secure.php.net/manual/en/class.reflectionclass.php" target="_blank">ReflectionClass</a> or
+    <a href="https://secure.php.net/manual/en/class.reflectionproperty.php" target="_blank">ReflectionProperty</a> is
     slow, and by slow, I mean <strong>really slow!</strong>
 </p>
 <p>
     The reason for this reasearch is that I'm trying to optimize a
-    "<a href="http://framework.zend.com/manual/2.2/en/modules/zend.stdlib.hydrator.html" target="_blank">hydrator</a>"
+    "<a href="https://framework.zend.com/manual/2.2/en/modules/zend.stdlib.hydrator.html" target="_blank">hydrator</a>"
     to work with larger data-sets by still keeping a low initialization overhead.
 </p>
 
@@ -35,7 +35,7 @@ tweet: 354936007868686337
 
 <p>
     PHP 5.4 comes with a new API for Closures, which is
-    <a href="http://php.net/manual/en/closure.bind.php" target="_blank"><code>Closure#bind()</code></a>.
+    <a href="https://secure.php.net/manual/en/closure.bind.php" target="_blank"><code>Closure#bind()</code></a>.
 </p>
 
 <p>
@@ -89,7 +89,7 @@ var_dump($sweetsThief($kitchen));
 ~~~
 
 <p>
-    Sadly, this <a href="http://3v4l.org/ET06l" target="_blank">will result</a> in <code>$sweetsThief</code>
+    Sadly, this <a href="https://3v4l.org/ET06l" target="_blank">will result</a> in <code>$sweetsThief</code>
     being caught with a fatal error that looks like following:
 </p>
 
@@ -113,7 +113,7 @@ var_dump($sweetsThief($kitchen));
 ~~~
 
 <p>
-    <a href="http://3v4l.org/2E2mr" target="_blank">Success</a>! We can now get to the <code>cake</code>!
+    <a href="https://3v4l.org/2E2mr" target="_blank">Success</a>! We can now get to the <code>cake</code>!
 </p>
 
 <hr/>
@@ -209,7 +209,7 @@ for ($i = 0; $i < 100000; $i += 1) {
 
 <p>
     There's actually one big advantage in using a Closure instead of ReflectionProperty, which is that you can
-    now <a href="http://3v4l.org/W12Hf" target="_blank">retrieve a private property by reference</a>!
+    now <a href="https://3v4l.org/W12Hf" target="_blank">retrieve a private property by reference</a>!
 </p>
 
 ~~~php
@@ -254,7 +254,7 @@ var_dump($kitchen);
 ~~~
 
 <p>
-    Here's the <a href="http://3v4l.org/JE0eX" target="_blank">working example</a>.
+    Here's the <a href="https://3v4l.org/JE0eX" target="_blank">working example</a>.
 </p>
 
 <p>

--- a/source/_posts/2013-08-09-fast-php-object-to-array-conversion.md
+++ b/source/_posts/2013-08-09-fast-php-object-to-array-conversion.md
@@ -34,7 +34,7 @@ $arrayFoo = (array) $foo;
 var_dump($arrayFoo);
 ~~~
 <p>
-    This <a href="http://3v4l.org/dj6Ei" target="_blank">will produce</a> something like:
+    This <a href="https://3v4l.org/dj6Ei" target="_blank">will produce</a> something like:
 </p>
 
 ~~~php
@@ -69,7 +69,7 @@ var_dump($arrayFoo);
 ~~~
 
 <p>
-    The output <a href="http://3v4l.org/vK1t6" target="_blank">will be</a> like following in this case:
+    The output <a href="https://3v4l.org/vK1t6" target="_blank">will be</a> like following in this case:
 </p>
 
 ~~~php
@@ -95,7 +95,7 @@ var_dump($arrayFoo['Footab']);
 
 <p>
     Something even more strange happens here:
-    <a href="http://3v4l.org/JimNP" target="_blank">we get two notices</a>.
+    <a href="https://3v4l.org/JimNP" target="_blank">we get two notices</a>.
 </p>
 
 ~~~php
@@ -109,7 +109,7 @@ NULL
 <p>
     I actually spent some time trying to understand why this was happening, and even the debugger was failing
     me! Then I tried using
-    <a href="http://www.php.net/manual/en/function.var-export.php" target="_blank"><code>var_export</code></a>:
+    <a href="https://secure.php.net/manual/en/function.var-export.php" target="_blank"><code>var_export</code></a>:
 </p>
 
 
@@ -120,7 +120,7 @@ var_export($arrayFoo);
 ~~~
 
 <p>
-    The <a href="http://3v4l.org/UQlb0" target="_blank">output</a> is quite interesting:
+    The <a href="https://3v4l.org/UQlb0" target="_blank">output</a> is quite interesting:
 </p>
 
 ~~~php
@@ -154,7 +154,7 @@ var_dump($foo->{"\0Foo\0tab"});
 
 <p>
     Looks like the engine was patched after PHP 5.1 to fix this (un-documented break),
-    since <a href="http://3v4l.org/e5hWG" target="_blank">we get a fatal</a>:
+    since <a href="https://3v4l.org/e5hWG" target="_blank">we get a fatal</a>:
 </p>
 
 ~~~php

--- a/source/_posts/2013-11-07-fluent-interfaces-are-evil.md
+++ b/source/_posts/2013-11-07-fluent-interfaces-are-evil.md
@@ -24,7 +24,7 @@ tweet: 399854614503108608
 <h2>Recap: What is a Fluent interface?</h2>
 
 <p>
-    A <a href="http://en.wikipedia.org/wiki/Fluent_interface" target="_blank">Fluent Interface</a>
+    A <a href="https://en.wikipedia.org/wiki/Fluent_interface" target="_blank">Fluent Interface</a>
     is an object oriented API that provides "more readable" code.
     <br/>
     In general, the template for a fluent interface can be like following:
@@ -100,7 +100,7 @@ $queryBuilder
 <ol>
     <li>
         Fluent Interfaces break
-        <a href="http://en.wikipedia.org/wiki/Encapsulation_%28object-oriented_programming%29" target="_blank">
+        <a href="https://en.wikipedia.org/wiki/Encapsulation_%28object-oriented_programming%29" target="_blank">
             Encapsulation
         </a>
     </li>
@@ -201,7 +201,7 @@ class ImmutableCounter implements Counter
 ~~~
 
 <p>
-    Here is how you <a href="http://3v4l.org/l5rr0" target="_blank">use a <code>FluentCounter</code></a>:
+    Here is how you <a href="https://3v4l.org/l5rr0" target="_blank">use a <code>FluentCounter</code></a>:
 </p>
 
 ~~~php
@@ -213,7 +213,7 @@ echo $counter->count()->count()->count()->getCount(); // 3!
 ~~~
 
 <p>
-    Here is how you <a href="http://3v4l.org/AP62m" target="_blank">use an <code>ImmutableCounter</code></a>:
+    Here is how you <a href="https://3v4l.org/AP62m" target="_blank">use an <code>ImmutableCounter</code></a>:
 </p>
 
 ~~~php
@@ -236,7 +236,7 @@ echo $counter->getCount(); // 3!
 </p>
 <p>
     Turns out that the only correct way of
-    <a href="http://3v4l.org/fILUc" target="_blank">using such an interface</a>
+    <a href="https://3v4l.org/fILUc" target="_blank">using such an interface</a>
     is the "immutable" way, so:
 </p>
 
@@ -339,7 +339,7 @@ class EchoingCounter implements Counter
 ~~~
 
 <p>
-    Let's <a href="http://3v4l.org/i5m5r" target="_blank">try it out with our fluent counter</a>:
+    Let's <a href="https://3v4l.org/i5m5r" target="_blank">try it out with our fluent counter</a>:
 </p>
 
 ~~~php
@@ -364,7 +364,7 @@ echo $counter->getCount();
 
 <p>
     Same happens when
-    <a href="http://3v4l.org/bUMJ7" target="_blank">using the <code>ImmutableCounter</code></a>
+    <a href="https://3v4l.org/bUMJ7" target="_blank">using the <code>ImmutableCounter</code></a>
 </p>
 
 ~~~php
@@ -409,7 +409,7 @@ class EchoingCounter implements Counter
 }
 ~~~
 
-<p>And now let's <a href="http://3v4l.org/AilJu" target="_blank">retry</a>:</p>
+<p>And now let's <a href="https://3v4l.org/AilJu" target="_blank">retry</a>:</p>
 
 ~~~php
 <?php
@@ -439,7 +439,7 @@ echo $counter->getCount();
 ~~~
 
 <p>
-    <a href="http://3v4l.org/FuX4X" target="_blank">Seems to work</a>, but if you look closely,
+    <a href="https://3v4l.org/FuX4X" target="_blank">Seems to work</a>, but if you look closely,
     the reported count is wrong. Now the wrapper is working, but not the real logic!
 </p>
 
@@ -501,7 +501,7 @@ class EchoingCounter implements Counter
 
 <p>
     Mock classes (at least in PHPUnit) are
-    <a href="http://en.wikipedia.org/wiki/Null_Object_pattern" target="_blank">null objects</a> by default,
+    <a href="https://en.wikipedia.org/wiki/Null_Object_pattern" target="_blank">null objects</a> by default,
     which means that all the return values of methods have to be manually defined:
 </p>
 
@@ -639,7 +639,7 @@ $ diff -p left.txt right.txt
 <p>
     This is a personal feeling, but when reading a fluent interface, I cannot recognize if what is going on
     is just a massive violation of the
-    <a href="http://en.wikipedia.org/wiki/Law_of_Demeter" target="_blank">Law of Demeter</a>, or if we're
+    <a href="https://en.wikipedia.org/wiki/Law_of_Demeter" target="_blank">Law of Demeter</a>, or if we're
     dealing with the same object over and over again.
     <br/>
     I'm picking an obvious example to show where this may happen:

--- a/source/_posts/2014-02-19-lazy-property-automatic-property-initialization.md
+++ b/source/_posts/2014-02-19-lazy-property-automatic-property-initialization.md
@@ -195,7 +195,7 @@ class UserService
 
 <p>
     What is going on? I'm simply exploiting an feature of the PHP language on which I've already
-    blogged at <a href="http://ocramius.github.io/blog/intercepting-public-property-access-in-php/" target="_blank">
+    blogged at <a href="https://ocramius.github.io/blog/intercepting-public-property-access-in-php/" target="_blank">
         Property Accessors in PHP Userland
     </a>.
 </p>

--- a/source/_posts/2014-03-16-zend-framework-2-delegator-factories-explained.md
+++ b/source/_posts/2014-03-16-zend-framework-2-delegator-factories-explained.md
@@ -16,7 +16,7 @@ tweet: 445250469188083713
     Last year, I
     <a href="https://github.com/zendframework/zf2/pull/4145" target="_blank">worked on a feature</a>
     for ZF2 called
-    <a href="http://framework.zend.com/manual/2.3/en/modules/zend.service-manager.delegator-factories.html" target="_blank">
+    <a href="https://framework.zend.com/manual/2.3/en/modules/zend.service-manager.delegator-factories.html" target="_blank">
         "Delegator Service Factories"
     </a>, which was included in Zend Framework 2.2.0.
 </p>
@@ -294,12 +294,12 @@ return [
 
 <p>
     I initially designed these factories to solve a different problem, which is
-    <a href="http://framework.zend.com/manual/2.3/en/modules/zend.service-manager.lazy-services.html" target="_blank">Lazy Services</a>.
+    <a href="https://framework.zend.com/manual/2.3/en/modules/zend.service-manager.lazy-services.html" target="_blank">Lazy Services</a>.
 </p>
 <p>
     In the context of lazy services and decorators, the instance returned by these factories
     is indeed a
-    "<a href="http://en.wikipedia.org/wiki/Delegation_pattern" target="_blank">delegate</a>",
+    "<a href="https://en.wikipedia.org/wiki/Delegation_pattern" target="_blank">delegate</a>",
     therefore I came up with the name "delegator factory".
 </p>
 <p>
@@ -324,7 +324,7 @@ return [
 
 <p>
     The entire functionality was introduced by accident while I was working on an implementation of
-    <a href="http://ocramius.github.io/blog/zf2-and-symfony-service-proxies-with-doctrine-proxies/" target="_blank">Lazy Services</a>,
+    <a href="https://ocramius.github.io/blog/zf2-and-symfony-service-proxies-with-doctrine-proxies/" target="_blank">Lazy Services</a>,
     and they surely need a rename. This will not happen in Zend Framework 2.x.
 </p>
 

--- a/source/_posts/2014-12-12-proxy-manager-1-0-0-release.md
+++ b/source/_posts/2014-12-12-proxy-manager-1-0-0-release.md
@@ -23,7 +23,7 @@ tweet: 543363692067565568
 <p>
     Today I finally released version 
     <a href="https://github.com/Ocramius/ProxyManager/releases/tag/1.0.0" target="_blank">1.0.0</a> of the 
-    <a href="http://ocramius.github.io/ProxyManager" target="_blank">ProxyManager</a>
+    <a href="https://ocramius.github.io/ProxyManager" target="_blank">ProxyManager</a>
 </p>
 
 <h3>Noticeable improvements since 0.5.2:</h3>

--- a/source/_posts/2015-01-06-when-to-declare-classes-final.md
+++ b/source/_posts/2015-01-06-when-to-declare-classes-final.md
@@ -101,7 +101,7 @@ class PatchedBot extends BotThatDoesSpecialThings { /* ... */ }
 <p>
     There will be less stuffing functionality in existing code via inheritance, which, in my
     opinion, is a symptom of haste combined with 
-    <a href="http://en.wikipedia.org/wiki/Feature_creep" target="_blank">feature creep</a>.
+    <a href="https://en.wikipedia.org/wiki/Feature_creep" target="_blank">feature creep</a>.
 </p>
 
 <p>

--- a/source/_posts/2016-01-29-proxy-manager-2-0-0-release.md
+++ b/source/_posts/2016-01-29-proxy-manager-2-0-0-release.md
@@ -21,7 +21,7 @@ tweet: 693368993881657344
 </p>
 
 <p>
-    <a href="http://ocramius.github.io/ProxyManager" target="_blank">ProxyManager</a>
+    <a href="https://ocramius.github.io/ProxyManager" target="_blank">ProxyManager</a>
     <a href="https://github.com/Ocramius/ProxyManager/releases/tag/2.0.0" target="_blank">2.0.0</a>
     was finally released today!
 </p>

--- a/source/about.md
+++ b/source/about.md
@@ -6,10 +6,10 @@ title: About me, Marco Pivetta, aka Ocramius
 
 <article class="vcard">
     <p>
-        Hi, my name is <a class="ocramius fn url" href="http://ocramius.github.io/">
+        Hi, my name is <a class="ocramius fn url" href="https://ocramius.github.io/">
             <span class="given-name">Marco</span> <span class="family-name">Pivetta</span>
         </a>,
-        and I'm a software consultant working for <a class="roave fn url org" href="http://roave.com/" target="_blank">Roave</a>.
+        and I'm a software consultant working for <a class="roave fn url org" href="https://roave.com/" target="_blank">Roave</a>.
     </p>
 
     <p class="adr">


### PR DESCRIPTION
Only some domains were moved to HTTPS:

1. 3v4l.org
1. getcomposer.org
1. github.com
1. github.io
1. martinfowler.com
1. mwop.net
1. php.net
1. travis-ci.org
1. twitter.com
1. wikipedia.org
1. zend.com